### PR TITLE
test: run tests offline

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -37,7 +37,8 @@ fi
 
 case ${JOB_TYPE} in
 test)
-    mvn test -B
+    mvn dependency:go-offline
+    mvn --fail-at-end -o verify
     bash ${KOKORO_GFILE_DIR}/codecov.sh
     ;;
 lint)

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -29,6 +29,7 @@ mvn install -B -V \
   -Dmaven.javadoc.skip=true \
   -Dgcloud.download.skip=true \
   -T 1C
+mvn dependency:go-offline
 
 # if GOOGLE_APPLICATION_CREDIENTIALS is specified as a relative path prepend Kokoro root directory onto it
 if [[ ! -z "${GOOGLE_APPLICATION_CREDENTIALS}" && "${GOOGLE_APPLICATION_CREDENTIALS}" != /* ]]; then
@@ -37,8 +38,7 @@ fi
 
 case ${JOB_TYPE} in
 test)
-    mvn dependency:go-offline
-    mvn --fail-at-end -o verify
+    mvn -B -o test
     bash ${KOKORO_GFILE_DIR}/codecov.sh
     ;;
 lint)
@@ -48,7 +48,7 @@ javadoc)
     mvn javadoc:javadoc javadoc:test-javadoc
     ;;
 integration)
-    mvn -B ${INTEGRATION_TEST_ARGS} -DtrimStackTrace=false -fae verify
+    mvn -B ${INTEGRATION_TEST_ARGS} -DtrimStackTrace=false -o -fae verify
     ;;
 *)
     ;;

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,19 @@
     <version>0.2.1-SNAPSHOT</version>
   </parent>
 
+  <repositories>
+    <repository>
+      <id>snapshots-repo</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
   <developers>
     <developer>
       <id>garrettjonesgoogle</id>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>0.2.0</version>
+    <version>0.2.1-SNAPSHOT</version>
   </parent>
 
   <developers>


### PR DESCRIPTION
Co-opting the normal Kokoro tests to run the tests/dependencies offline. If this does find issues and is necessary, we can turn this into a real test that we run in parallel to the normal, online tests.

Testing #16 