### PR TITLE
chore: Migrate speech synth.py to bazel

### DIFF
--- a/grpc-google-cloud-speech-v1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-speech-v1/clirr-ignored-differences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 1.22.6 released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/cloud/speech/v1/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/grpc-google-cloud-speech-v1/src/main/java/com/google/cloud/speech/v1/SpeechGrpc.java
+++ b/grpc-google-cloud-speech-v1/src/main/java/com/google/cloud/speech/v1/SpeechGrpc.java
@@ -33,7 +33,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/speech/v1/cloud_speech.proto")
 public final class SpeechGrpc {
 
@@ -42,26 +42,18 @@ public final class SpeechGrpc {
   public static final String SERVICE_NAME = "google.cloud.speech.v1.Speech";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getRecognizeMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.speech.v1.RecognizeRequest, com.google.cloud.speech.v1.RecognizeResponse>
-      METHOD_RECOGNIZE = getRecognizeMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.speech.v1.RecognizeRequest, com.google.cloud.speech.v1.RecognizeResponse>
       getRecognizeMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "Recognize",
+      requestType = com.google.cloud.speech.v1.RecognizeRequest.class,
+      responseType = com.google.cloud.speech.v1.RecognizeResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.speech.v1.RecognizeRequest, com.google.cloud.speech.v1.RecognizeResponse>
       getRecognizeMethod() {
-    return getRecognizeMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.speech.v1.RecognizeRequest, com.google.cloud.speech.v1.RecognizeResponse>
-      getRecognizeMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.speech.v1.RecognizeRequest,
             com.google.cloud.speech.v1.RecognizeResponse>
@@ -76,8 +68,7 @@ public final class SpeechGrpc {
                           com.google.cloud.speech.v1.RecognizeResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("google.cloud.speech.v1.Speech", "Recognize"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "Recognize"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -93,26 +84,18 @@ public final class SpeechGrpc {
     return getRecognizeMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getLongRunningRecognizeMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.speech.v1.LongRunningRecognizeRequest, com.google.longrunning.Operation>
-      METHOD_LONG_RUNNING_RECOGNIZE = getLongRunningRecognizeMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.speech.v1.LongRunningRecognizeRequest, com.google.longrunning.Operation>
       getLongRunningRecognizeMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "LongRunningRecognize",
+      requestType = com.google.cloud.speech.v1.LongRunningRecognizeRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.speech.v1.LongRunningRecognizeRequest, com.google.longrunning.Operation>
       getLongRunningRecognizeMethod() {
-    return getLongRunningRecognizeMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.speech.v1.LongRunningRecognizeRequest, com.google.longrunning.Operation>
-      getLongRunningRecognizeMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.speech.v1.LongRunningRecognizeRequest,
             com.google.longrunning.Operation>
@@ -128,8 +111,7 @@ public final class SpeechGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.speech.v1.Speech", "LongRunningRecognize"))
+                          generateFullMethodName(SERVICE_NAME, "LongRunningRecognize"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -147,30 +129,20 @@ public final class SpeechGrpc {
     return getLongRunningRecognizeMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getStreamingRecognizeMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.speech.v1.StreamingRecognizeRequest,
-          com.google.cloud.speech.v1.StreamingRecognizeResponse>
-      METHOD_STREAMING_RECOGNIZE = getStreamingRecognizeMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.speech.v1.StreamingRecognizeRequest,
           com.google.cloud.speech.v1.StreamingRecognizeResponse>
       getStreamingRecognizeMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "StreamingRecognize",
+      requestType = com.google.cloud.speech.v1.StreamingRecognizeRequest.class,
+      responseType = com.google.cloud.speech.v1.StreamingRecognizeResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.speech.v1.StreamingRecognizeRequest,
           com.google.cloud.speech.v1.StreamingRecognizeResponse>
       getStreamingRecognizeMethod() {
-    return getStreamingRecognizeMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.speech.v1.StreamingRecognizeRequest,
-          com.google.cloud.speech.v1.StreamingRecognizeResponse>
-      getStreamingRecognizeMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.speech.v1.StreamingRecognizeRequest,
             com.google.cloud.speech.v1.StreamingRecognizeResponse>
@@ -185,9 +157,7 @@ public final class SpeechGrpc {
                           com.google.cloud.speech.v1.StreamingRecognizeResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.speech.v1.Speech", "StreamingRecognize"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "StreamingRecognize"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -207,19 +177,42 @@ public final class SpeechGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static SpeechStub newStub(io.grpc.Channel channel) {
-    return new SpeechStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SpeechStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<SpeechStub>() {
+          @java.lang.Override
+          public SpeechStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new SpeechStub(channel, callOptions);
+          }
+        };
+    return SpeechStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static SpeechBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new SpeechBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SpeechBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<SpeechBlockingStub>() {
+          @java.lang.Override
+          public SpeechBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new SpeechBlockingStub(channel, callOptions);
+          }
+        };
+    return SpeechBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static SpeechFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new SpeechFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SpeechFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<SpeechFutureStub>() {
+          @java.lang.Override
+          public SpeechFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new SpeechFutureStub(channel, callOptions);
+          }
+        };
+    return SpeechFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -243,7 +236,7 @@ public final class SpeechGrpc {
         com.google.cloud.speech.v1.RecognizeRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.speech.v1.RecognizeResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getRecognizeMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getRecognizeMethod(), responseObserver);
     }
 
     /**
@@ -261,7 +254,7 @@ public final class SpeechGrpc {
     public void longRunningRecognize(
         com.google.cloud.speech.v1.LongRunningRecognizeRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getLongRunningRecognizeMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getLongRunningRecognizeMethod(), responseObserver);
     }
 
     /**
@@ -276,26 +269,26 @@ public final class SpeechGrpc {
         streamingRecognize(
             io.grpc.stub.StreamObserver<com.google.cloud.speech.v1.StreamingRecognizeResponse>
                 responseObserver) {
-      return asyncUnimplementedStreamingCall(getStreamingRecognizeMethodHelper(), responseObserver);
+      return asyncUnimplementedStreamingCall(getStreamingRecognizeMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getRecognizeMethodHelper(),
+              getRecognizeMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.speech.v1.RecognizeRequest,
                       com.google.cloud.speech.v1.RecognizeResponse>(this, METHODID_RECOGNIZE)))
           .addMethod(
-              getLongRunningRecognizeMethodHelper(),
+              getLongRunningRecognizeMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.speech.v1.LongRunningRecognizeRequest,
                       com.google.longrunning.Operation>(this, METHODID_LONG_RUNNING_RECOGNIZE)))
           .addMethod(
-              getStreamingRecognizeMethodHelper(),
+              getStreamingRecognizeMethod(),
               asyncBidiStreamingCall(
                   new MethodHandlers<
                       com.google.cloud.speech.v1.StreamingRecognizeRequest,
@@ -312,11 +305,7 @@ public final class SpeechGrpc {
    * Service that implements Google Cloud Speech API.
    * </pre>
    */
-  public static final class SpeechStub extends io.grpc.stub.AbstractStub<SpeechStub> {
-    private SpeechStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class SpeechStub extends io.grpc.stub.AbstractAsyncStub<SpeechStub> {
     private SpeechStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -339,9 +328,7 @@ public final class SpeechGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.speech.v1.RecognizeResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getRecognizeMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getRecognizeMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -360,7 +347,7 @@ public final class SpeechGrpc {
         com.google.cloud.speech.v1.LongRunningRecognizeRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getLongRunningRecognizeMethodHelper(), getCallOptions()),
+          getChannel().newCall(getLongRunningRecognizeMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -378,8 +365,7 @@ public final class SpeechGrpc {
             io.grpc.stub.StreamObserver<com.google.cloud.speech.v1.StreamingRecognizeResponse>
                 responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(getStreamingRecognizeMethodHelper(), getCallOptions()),
-          responseObserver);
+          getChannel().newCall(getStreamingRecognizeMethod(), getCallOptions()), responseObserver);
     }
   }
 
@@ -391,11 +377,7 @@ public final class SpeechGrpc {
    * </pre>
    */
   public static final class SpeechBlockingStub
-      extends io.grpc.stub.AbstractStub<SpeechBlockingStub> {
-    private SpeechBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<SpeechBlockingStub> {
     private SpeechBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -415,7 +397,7 @@ public final class SpeechGrpc {
      */
     public com.google.cloud.speech.v1.RecognizeResponse recognize(
         com.google.cloud.speech.v1.RecognizeRequest request) {
-      return blockingUnaryCall(getChannel(), getRecognizeMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getRecognizeMethod(), getCallOptions(), request);
     }
 
     /**
@@ -433,7 +415,7 @@ public final class SpeechGrpc {
     public com.google.longrunning.Operation longRunningRecognize(
         com.google.cloud.speech.v1.LongRunningRecognizeRequest request) {
       return blockingUnaryCall(
-          getChannel(), getLongRunningRecognizeMethodHelper(), getCallOptions(), request);
+          getChannel(), getLongRunningRecognizeMethod(), getCallOptions(), request);
     }
   }
 
@@ -444,11 +426,8 @@ public final class SpeechGrpc {
    * Service that implements Google Cloud Speech API.
    * </pre>
    */
-  public static final class SpeechFutureStub extends io.grpc.stub.AbstractStub<SpeechFutureStub> {
-    private SpeechFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class SpeechFutureStub
+      extends io.grpc.stub.AbstractFutureStub<SpeechFutureStub> {
     private SpeechFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -469,8 +448,7 @@ public final class SpeechGrpc {
     public com.google.common.util.concurrent.ListenableFuture<
             com.google.cloud.speech.v1.RecognizeResponse>
         recognize(com.google.cloud.speech.v1.RecognizeRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getRecognizeMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getRecognizeMethod(), getCallOptions()), request);
     }
 
     /**
@@ -488,7 +466,7 @@ public final class SpeechGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         longRunningRecognize(com.google.cloud.speech.v1.LongRunningRecognizeRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getLongRunningRecognizeMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getLongRunningRecognizeMethod(), getCallOptions()), request);
     }
   }
 
@@ -592,9 +570,9 @@ public final class SpeechGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new SpeechFileDescriptorSupplier())
-                      .addMethod(getRecognizeMethodHelper())
-                      .addMethod(getLongRunningRecognizeMethodHelper())
-                      .addMethod(getStreamingRecognizeMethodHelper())
+                      .addMethod(getRecognizeMethod())
+                      .addMethod(getLongRunningRecognizeMethod())
+                      .addMethod(getStreamingRecognizeMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-speech-v1beta1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-speech-v1beta1/clirr-ignored-differences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 1.22.6 released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/cloud/speech/v1beta1/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/grpc-google-cloud-speech-v1p1beta1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-speech-v1p1beta1/clirr-ignored-differences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 1.22.6 released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/cloud/speech/v1p1beta1/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/grpc-google-cloud-speech-v1p1beta1/src/main/java/com/google/cloud/speech/v1p1beta1/SpeechGrpc.java
+++ b/grpc-google-cloud-speech-v1p1beta1/src/main/java/com/google/cloud/speech/v1p1beta1/SpeechGrpc.java
@@ -33,7 +33,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/speech/v1p1beta1/cloud_speech.proto")
 public final class SpeechGrpc {
 
@@ -42,30 +42,20 @@ public final class SpeechGrpc {
   public static final String SERVICE_NAME = "google.cloud.speech.v1p1beta1.Speech";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getRecognizeMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.speech.v1p1beta1.RecognizeRequest,
-          com.google.cloud.speech.v1p1beta1.RecognizeResponse>
-      METHOD_RECOGNIZE = getRecognizeMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.speech.v1p1beta1.RecognizeRequest,
           com.google.cloud.speech.v1p1beta1.RecognizeResponse>
       getRecognizeMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "Recognize",
+      requestType = com.google.cloud.speech.v1p1beta1.RecognizeRequest.class,
+      responseType = com.google.cloud.speech.v1p1beta1.RecognizeResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.speech.v1p1beta1.RecognizeRequest,
           com.google.cloud.speech.v1p1beta1.RecognizeResponse>
       getRecognizeMethod() {
-    return getRecognizeMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.speech.v1p1beta1.RecognizeRequest,
-          com.google.cloud.speech.v1p1beta1.RecognizeResponse>
-      getRecognizeMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.speech.v1p1beta1.RecognizeRequest,
             com.google.cloud.speech.v1p1beta1.RecognizeResponse>
@@ -80,9 +70,7 @@ public final class SpeechGrpc {
                           com.google.cloud.speech.v1p1beta1.RecognizeResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.speech.v1p1beta1.Speech", "Recognize"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "Recognize"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -100,30 +88,20 @@ public final class SpeechGrpc {
     return getRecognizeMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getLongRunningRecognizeMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest,
-          com.google.longrunning.Operation>
-      METHOD_LONG_RUNNING_RECOGNIZE = getLongRunningRecognizeMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest,
           com.google.longrunning.Operation>
       getLongRunningRecognizeMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "LongRunningRecognize",
+      requestType = com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest,
           com.google.longrunning.Operation>
       getLongRunningRecognizeMethod() {
-    return getLongRunningRecognizeMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest,
-          com.google.longrunning.Operation>
-      getLongRunningRecognizeMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest,
             com.google.longrunning.Operation>
@@ -139,8 +117,7 @@ public final class SpeechGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.speech.v1p1beta1.Speech", "LongRunningRecognize"))
+                          generateFullMethodName(SERVICE_NAME, "LongRunningRecognize"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -158,30 +135,20 @@ public final class SpeechGrpc {
     return getLongRunningRecognizeMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getStreamingRecognizeMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest,
-          com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse>
-      METHOD_STREAMING_RECOGNIZE = getStreamingRecognizeMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest,
           com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse>
       getStreamingRecognizeMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "StreamingRecognize",
+      requestType = com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.class,
+      responseType = com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest,
           com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse>
       getStreamingRecognizeMethod() {
-    return getStreamingRecognizeMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest,
-          com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse>
-      getStreamingRecognizeMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest,
             com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse>
@@ -196,9 +163,7 @@ public final class SpeechGrpc {
                           com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.speech.v1p1beta1.Speech", "StreamingRecognize"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "StreamingRecognize"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -218,19 +183,42 @@ public final class SpeechGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static SpeechStub newStub(io.grpc.Channel channel) {
-    return new SpeechStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SpeechStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<SpeechStub>() {
+          @java.lang.Override
+          public SpeechStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new SpeechStub(channel, callOptions);
+          }
+        };
+    return SpeechStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static SpeechBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new SpeechBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SpeechBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<SpeechBlockingStub>() {
+          @java.lang.Override
+          public SpeechBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new SpeechBlockingStub(channel, callOptions);
+          }
+        };
+    return SpeechBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static SpeechFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new SpeechFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SpeechFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<SpeechFutureStub>() {
+          @java.lang.Override
+          public SpeechFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new SpeechFutureStub(channel, callOptions);
+          }
+        };
+    return SpeechFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -254,7 +242,7 @@ public final class SpeechGrpc {
         com.google.cloud.speech.v1p1beta1.RecognizeRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.speech.v1p1beta1.RecognizeResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getRecognizeMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getRecognizeMethod(), responseObserver);
     }
 
     /**
@@ -272,7 +260,7 @@ public final class SpeechGrpc {
     public void longRunningRecognize(
         com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getLongRunningRecognizeMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getLongRunningRecognizeMethod(), responseObserver);
     }
 
     /**
@@ -288,27 +276,27 @@ public final class SpeechGrpc {
             io.grpc.stub.StreamObserver<
                     com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse>
                 responseObserver) {
-      return asyncUnimplementedStreamingCall(getStreamingRecognizeMethodHelper(), responseObserver);
+      return asyncUnimplementedStreamingCall(getStreamingRecognizeMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getRecognizeMethodHelper(),
+              getRecognizeMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.speech.v1p1beta1.RecognizeRequest,
                       com.google.cloud.speech.v1p1beta1.RecognizeResponse>(
                       this, METHODID_RECOGNIZE)))
           .addMethod(
-              getLongRunningRecognizeMethodHelper(),
+              getLongRunningRecognizeMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest,
                       com.google.longrunning.Operation>(this, METHODID_LONG_RUNNING_RECOGNIZE)))
           .addMethod(
-              getStreamingRecognizeMethodHelper(),
+              getStreamingRecognizeMethod(),
               asyncBidiStreamingCall(
                   new MethodHandlers<
                       com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest,
@@ -325,11 +313,7 @@ public final class SpeechGrpc {
    * Service that implements Google Cloud Speech API.
    * </pre>
    */
-  public static final class SpeechStub extends io.grpc.stub.AbstractStub<SpeechStub> {
-    private SpeechStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class SpeechStub extends io.grpc.stub.AbstractAsyncStub<SpeechStub> {
     private SpeechStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -352,9 +336,7 @@ public final class SpeechGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.speech.v1p1beta1.RecognizeResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getRecognizeMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getRecognizeMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -373,7 +355,7 @@ public final class SpeechGrpc {
         com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getLongRunningRecognizeMethodHelper(), getCallOptions()),
+          getChannel().newCall(getLongRunningRecognizeMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -392,8 +374,7 @@ public final class SpeechGrpc {
                     com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse>
                 responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(getStreamingRecognizeMethodHelper(), getCallOptions()),
-          responseObserver);
+          getChannel().newCall(getStreamingRecognizeMethod(), getCallOptions()), responseObserver);
     }
   }
 
@@ -405,11 +386,7 @@ public final class SpeechGrpc {
    * </pre>
    */
   public static final class SpeechBlockingStub
-      extends io.grpc.stub.AbstractStub<SpeechBlockingStub> {
-    private SpeechBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<SpeechBlockingStub> {
     private SpeechBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -429,7 +406,7 @@ public final class SpeechGrpc {
      */
     public com.google.cloud.speech.v1p1beta1.RecognizeResponse recognize(
         com.google.cloud.speech.v1p1beta1.RecognizeRequest request) {
-      return blockingUnaryCall(getChannel(), getRecognizeMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getRecognizeMethod(), getCallOptions(), request);
     }
 
     /**
@@ -447,7 +424,7 @@ public final class SpeechGrpc {
     public com.google.longrunning.Operation longRunningRecognize(
         com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest request) {
       return blockingUnaryCall(
-          getChannel(), getLongRunningRecognizeMethodHelper(), getCallOptions(), request);
+          getChannel(), getLongRunningRecognizeMethod(), getCallOptions(), request);
     }
   }
 
@@ -458,11 +435,8 @@ public final class SpeechGrpc {
    * Service that implements Google Cloud Speech API.
    * </pre>
    */
-  public static final class SpeechFutureStub extends io.grpc.stub.AbstractStub<SpeechFutureStub> {
-    private SpeechFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class SpeechFutureStub
+      extends io.grpc.stub.AbstractFutureStub<SpeechFutureStub> {
     private SpeechFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -483,8 +457,7 @@ public final class SpeechGrpc {
     public com.google.common.util.concurrent.ListenableFuture<
             com.google.cloud.speech.v1p1beta1.RecognizeResponse>
         recognize(com.google.cloud.speech.v1p1beta1.RecognizeRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getRecognizeMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getRecognizeMethod(), getCallOptions()), request);
     }
 
     /**
@@ -503,7 +476,7 @@ public final class SpeechGrpc {
         longRunningRecognize(
             com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getLongRunningRecognizeMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getLongRunningRecognizeMethod(), getCallOptions()), request);
     }
   }
 
@@ -607,9 +580,9 @@ public final class SpeechGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new SpeechFileDescriptorSupplier())
-                      .addMethod(getRecognizeMethodHelper())
-                      .addMethod(getLongRunningRecognizeMethodHelper())
-                      .addMethod(getStreamingRecognizeMethodHelper())
+                      .addMethod(getRecognizeMethod())
+                      .addMethod(getLongRunningRecognizeMethod())
+                      .addMethod(getStreamingRecognizeMethod())
                       .build();
         }
       }

--- a/synth.py
+++ b/synth.py
@@ -14,23 +14,16 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import synthtool as s
-import synthtool.gcp as gcp
 import synthtool.languages.java as java
-
-gapic = gcp.GAPICGenerator()
 
 service = 'speech'
 versions = ['v1', 'v1p1beta1']
-config_pattern = '/google/cloud/speech/artman_speech_{version}.yaml'
 
 for version in versions:
-  java.gapic_library(
-    service=service,
-    version=version,
-    config_pattern=config_pattern,
-    package_pattern='com.google.cloud.{service}.{version}',
-    gapic=gapic,
+  library = java.bazel_library(
+      service=service,
+      version=version,
+      bazel_target=f'//google/cloud/{service}/{version}:google-cloud-{service}-{version}-java',
   )
 
 java.common_templates()


### PR DESCRIPTION
The changes in grpc stubs are caused by the gRPC upgrade from 1.10 (more than a year old) to 1.27 (same version which is used as runtime dependency)

